### PR TITLE
Update setup.py, exclude tests from installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description="Asynchronous library to retrieve data from PEGELONLINE.",
     long_description=README_FILE.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
-    packages=find_packages(exclude=["tests","tests.*"]),
+    packages=["aiopegelonline"],
     python_requires=">=3.9",
     package_data={"aiopegelonline": ["py.typed"]},
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description="Asynchronous library to retrieve data from PEGELONLINE.",
     long_description=README_FILE.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests","tests.*"]),
     python_requires=">=3.9",
     package_data={"aiopegelonline": ["py.typed"]},
     zip_safe=True,


### PR DESCRIPTION
otherwise:

```
 * python3_11: running distutils-r1_run_phase distutils-r1_python_install
 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.11/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/aiopegelonline-0.0.6::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages
```