### PR TITLE
Log stack trace only on debug level

### DIFF
--- a/aiopegelonline/__init__.py
+++ b/aiopegelonline/__init__.py
@@ -50,7 +50,12 @@ class PegelOnline:
                         result.get("status"), result.get("message")
                     )
         except CONNECT_ERRORS as err:
-            LOGGER.exception("Error while getting data: %s", err.__class__.__name__)
+            LOGGER.debug("connection error", exc_info=True)
+            LOGGER.error(
+                "Error while getting data: %s: %s",
+                err.__class__.__name__,
+                err.__class__.__cause__,
+            )
             raise err
 
         return result


### PR DESCRIPTION
This avoids such long stack trace logs

```
2024-12-29 20:36:37.119 ERROR (MainThread) [aiopegelonline] Error while getting data: ClientConnectorDNSError
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/aiohttp/resolver.py", line 103, in resolve
    resp = await self._resolver.getaddrinfo(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
aiodns.error.DNSError: (12, 'Timeout while contacting DNS servers')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1351, in _create_direct_connection
    hosts = await self._resolve_host(host, port, traces=traces)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 970, in _resolve_host
    await future
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1026, in _resolve_host_with_throttle
    addrs = await self._resolver.resolve(host, port, family=self._family)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/resolver.py", line 112, in resolve
    raise OSError(None, msg) from exc
OSError: [Errno None] Timeout while contacting DNS servers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/aiopegelonline/__init__.py", line 36, in _async_do_request
    async with self.session.get(url, params=params, headers=headers) as resp:
               ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client.py", line 1425, in __aenter__
    self._resp: _RetType = await self._coro
                           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client.py", line 703, in _request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        req, traces=traces, timeout=real_timeout
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 548, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1056, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1357, in _create_direct_connection
    raise ClientConnectorDNSError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorDNSError: Cannot connect to host www.pegelonline.wsv.de:443 ssl:default [Timeout while contacting DNS servers]
```